### PR TITLE
Fix theme-switch flash and change to building new themes dynamically.

### DIFF
--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -3,7 +3,7 @@ USE bigmood_db;
 
 INSERT INTO themes (name)
 VALUES
-("gray"),
+("grey"),
 ("black"),
 ("red"),
 ("blue"),

--- a/models/theme.js
+++ b/models/theme.js
@@ -3,9 +3,9 @@ module.exports = (sequelize, DataTypes) => {
     name: {
       type: DataTypes.STRING(10),
       allowNull: false,
-      defaultValue: "gray",
+      defaultValue: "grey",
       validate: {
-        isIn: [["gray", "black", "red", "blue", "green"]]
+        isIn: [["grey", "black", "red", "blue", "green"]]
       }
     }
   }, {

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -7,8 +7,16 @@ h5 {
   margin-bottom: 1.5rem;  
 }
 
+nav {
+  background-color: transparent;
+}
+
 .btn-large {
   border-radius: 6px;
+}
+
+.dropdown-trigger {
+  background-color: transparent;
 }
 
 .card-content {
@@ -25,6 +33,7 @@ h5 {
 }
 
 .dev-team {
+  background-color: transparent;
   margin-bottom: 2rem;
   border-radius: 2rem;
   display: flex;
@@ -59,12 +68,13 @@ h5 {
 }
 
 #dashContent {
-  background-color: lightgray;
+  background-color: transparent;
   align-content: center;
   margin-top: 1rem;
 }
 
 #modalButton {
+  background-color: transparent;
   position: sticky;
   right: 0;
   bottom: 0;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -185,60 +185,41 @@ $(document).ready(function () {
 
   }
 
-
   // Function to change color class based on the themeId
-  function displayTheme(theme) {
+  function displayTheme(color) {
     const themeSwitch = $(".theme-switch");
     const themeText = $(".theme-text");
-    let color;
-    switch (theme) {
-    case 2: color = "black";
-      break;
-    case 3: color = "red";
-      break;
-    case 4: color = "blue";
-      break;
-    case 5: color = "green";
-      break;
-    default: color = "grey";
-    }
-    themeSwitch.each(function () {
-      if ((themeSwitch.hasClass("red"))) {
-        themeSwitch.removeClass("red");
-      }
-      if ((themeSwitch.hasClass("blue"))) {
-        themeSwitch.removeClass("blue");
-      }
-      if ((themeSwitch.hasClass("green"))) {
-        themeSwitch.removeClass("green");
-      }
-      if ((themeSwitch.hasClass("black"))) {
-        themeSwitch.removeClass("black");
-      }
-      if ((themeSwitch.hasClass("grey"))) {
-        themeSwitch.removeClass("grey");
-      }
-      themeSwitch.addClass(color);
-    });
 
-    // Change text color
-    themeText.each(function() {
-      if((themeText.hasClass("red-text"))){
-        themeText.removeClass("red-text");
+    let themeObj;
+    let themeList = [];
+    // Get all themes from the table db
+    $.get("/api/themes").then((data) => {
+      for (let i = 0; i < data.length; i++){
+        themeObj = {
+          id: data[i].id,
+          name: data[i].name
+        };
+        themeList.push(themeObj);
       }
-      if((themeText.hasClass("blue-text"))){
-        themeText.removeClass("blue-text");
-      }
-      if((themeText.hasClass("green-text"))){
-        themeText.removeClass("green-text");
-      }
-      if((themeText.hasClass("black-text"))){
-        themeText.removeClass("black-text");
-      }
-      if ((themeText.hasClass("grey-text"))) {
-        themeText.removeClass("grey-text");
-      }
-      themeText.addClass(`${color}-text`);
+      // Change background color
+      themeSwitch.each(() => {
+        for (let i = 0; i < themeList.length; i++){
+          if ((themeSwitch.hasClass(themeList[i].name))) {
+            themeSwitch.removeClass(themeList[i].name);
+          }
+        }
+        themeSwitch.addClass(color);
+      });
+
+      // Change text color
+      themeText.each(() => {
+        for (let i = 0; i < themeList.length; i++){
+          if ((themeText.hasClass(`${themeList[i].name}-text`))) {
+            themeText.removeClass(`${themeList[i].name}-text`);
+          }
+        }
+        themeText.addClass(`${color}-text`);
+      });
     });
   }
 
@@ -246,9 +227,8 @@ $(document).ready(function () {
   // Get the current theme for the current user
   function getTheme(id) {
     $.get(`/api/users/${id}`).then((data) => {
-      let userTheme = data.Theme.id; // current user Theme
       let theme = data.Theme.name; // current Theme name
-      displayTheme(userTheme);
+      displayTheme(theme);
       statChart(id, theme); // Display Chart with theme
       return theme;
     });

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -191,63 +191,44 @@ $(document).ready(function () {
     const themeSwitch = $(".theme-switch");
     const themeText = $(".theme-text");
     let color;
-    switch (theme) {
-    case 2: color = "black";
-      break;
-    case 3: color = "red";
-      break;
-    case 4: color = "blue";
-      break;
-    case 5: color = "green";
-      break;
-    default: color = "grey";
-    }
-    themeSwitch.each(function () {
-      if ((themeSwitch.hasClass("red"))) {
-        themeSwitch.removeClass("red");
+    let themeObj; themeList = [];
+    $.get("/api/themes").then((data) => {
+      for (let i = 0; i < data.length; i++){
+        themeObj = {
+          id: data[i].id,
+          name: data[i].name
+        };
+        if (themeObj.id === theme) {
+          color = themeObj.name;
+        }
+        themeList.push(themeObj);
       }
-      if ((themeSwitch.hasClass("blue"))) {
-        themeSwitch.removeClass("blue");
-      }
-      if ((themeSwitch.hasClass("green"))) {
-        themeSwitch.removeClass("green");
-      }
-      if ((themeSwitch.hasClass("black"))) {
-        themeSwitch.removeClass("black");
-      }
-      if ((themeSwitch.hasClass("grey"))) {
-        themeSwitch.removeClass("grey");
-      }
-      themeSwitch.addClass(color);
-    });
+      // Change background color
+      themeSwitch.each(() => {
+        for (let i = 0; i < themeList.length; i++){
+          if ((themeSwitch.hasClass(themeList[i].name))) {
+            themeSwitch.removeClass(themeList[i].name);
+          }
+        }
+        themeSwitch.addClass(color);
+      });
 
-    // Change text color
-    themeText.each(function() {
-      if((themeText.hasClass("red-text"))){
-        themeText.removeClass("red-text");
-      }
-      if((themeText.hasClass("blue-text"))){
-        themeText.removeClass("blue-text");
-      }
-      if((themeText.hasClass("green-text"))){
-        themeText.removeClass("green-text");
-      }
-      if((themeText.hasClass("black-text"))){
-        themeText.removeClass("black-text");
-      }
-      if ((themeText.hasClass("grey-text"))) {
-        themeText.removeClass("grey-text");
-      }
-      themeText.addClass(`${color}-text`);
+      // Change text color
+      themeText.each(() => {
+        for (let i = 0; i < themeList.length; i++){
+          if ((themeText.hasClass(`${themeList[i].name}-text`))) {
+            themeText.removeClass(`${themeList[i].name}-text`);
+          }
+        }
+        themeText.addClass(`${color}-text`);
+      });
     });
   }
-
-
   // Get the current theme for the current user
   function getTheme(id) {
     $.get(`/api/users/${id}`).then((data) => {
-      let userTheme = data.Theme.id; // current user Theme
-      let theme = data.Theme.name; // current Theme name
+      let userTheme = data.Theme.id; // Current user Theme
+      let theme = data.Theme.name; // Current Theme name
       displayTheme(userTheme);
       statChart(id, theme); // Display Chart with theme
       return theme;
@@ -365,7 +346,7 @@ $(document).ready(function () {
     newEntry(userId);
   });
 
-  // Dropdown listeners
+  // Dropdown 1 listener
   $("#dropdown1").click(e => {
     newTheme = e.target.firstChild.textContent;
     themeId = e.target.getAttributeNode("data-id").value;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -191,44 +191,63 @@ $(document).ready(function () {
     const themeSwitch = $(".theme-switch");
     const themeText = $(".theme-text");
     let color;
-    let themeObj; themeList = [];
-    $.get("/api/themes").then((data) => {
-      for (let i = 0; i < data.length; i++){
-        themeObj = {
-          id: data[i].id,
-          name: data[i].name
-        };
-        if (themeObj.id === theme) {
-          color = themeObj.name;
-        }
-        themeList.push(themeObj);
+    switch (theme) {
+    case 2: color = "black";
+      break;
+    case 3: color = "red";
+      break;
+    case 4: color = "blue";
+      break;
+    case 5: color = "green";
+      break;
+    default: color = "grey";
+    }
+    themeSwitch.each(function () {
+      if ((themeSwitch.hasClass("red"))) {
+        themeSwitch.removeClass("red");
       }
-      // Change background color
-      themeSwitch.each(() => {
-        for (let i = 0; i < themeList.length; i++){
-          if ((themeSwitch.hasClass(themeList[i].name))) {
-            themeSwitch.removeClass(themeList[i].name);
-          }
-        }
-        themeSwitch.addClass(color);
-      });
+      if ((themeSwitch.hasClass("blue"))) {
+        themeSwitch.removeClass("blue");
+      }
+      if ((themeSwitch.hasClass("green"))) {
+        themeSwitch.removeClass("green");
+      }
+      if ((themeSwitch.hasClass("black"))) {
+        themeSwitch.removeClass("black");
+      }
+      if ((themeSwitch.hasClass("grey"))) {
+        themeSwitch.removeClass("grey");
+      }
+      themeSwitch.addClass(color);
+    });
 
-      // Change text color
-      themeText.each(() => {
-        for (let i = 0; i < themeList.length; i++){
-          if ((themeText.hasClass(`${themeList[i].name}-text`))) {
-            themeText.removeClass(`${themeList[i].name}-text`);
-          }
-        }
-        themeText.addClass(`${color}-text`);
-      });
+    // Change text color
+    themeText.each(function() {
+      if((themeText.hasClass("red-text"))){
+        themeText.removeClass("red-text");
+      }
+      if((themeText.hasClass("blue-text"))){
+        themeText.removeClass("blue-text");
+      }
+      if((themeText.hasClass("green-text"))){
+        themeText.removeClass("green-text");
+      }
+      if((themeText.hasClass("black-text"))){
+        themeText.removeClass("black-text");
+      }
+      if ((themeText.hasClass("grey-text"))) {
+        themeText.removeClass("grey-text");
+      }
+      themeText.addClass(`${color}-text`);
     });
   }
+
+
   // Get the current theme for the current user
   function getTheme(id) {
     $.get(`/api/users/${id}`).then((data) => {
-      let userTheme = data.Theme.id; // Current user Theme
-      let theme = data.Theme.name; // Current Theme name
+      let userTheme = data.Theme.id; // current user Theme
+      let theme = data.Theme.name; // current Theme name
       displayTheme(userTheme);
       statChart(id, theme); // Display Chart with theme
       return theme;
@@ -346,7 +365,7 @@ $(document).ready(function () {
     newEntry(userId);
   });
 
-  // Dropdown 1 listener
+  // Dropdown listeners
   $("#dropdown1").click(e => {
     newTheme = e.target.firstChild.textContent;
     themeId = e.target.getAttributeNode("data-id").value;

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -39,12 +39,15 @@ module.exports = function (app) {
 
     const result3 = await db.Activity.findAll();
 
+    const result4 = await db.Theme.findAll();
+
 
     res.render("dashboard", {
       style: "dashboard.css",
       entries: result1,
       moods: result2,
-      activities: result3
+      activities: result3,
+      themes: result4
     });
   });
 

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -38,16 +38,18 @@ module.exports = function (app) {
     const result2 = await db.Mood.findAll();
 
     const result3 = await db.Activity.findAll();
+    
+    const result4 = await db.Theme.findAll();
 
 
     res.render("dashboard", {
       style: "dashboard.css",
       entries: result1,
       moods: result2,
-      activities: result3
+      activities: result3,
+      themes: result4
     });
   });
-
 
   // Route for logging user out
   app.get("/logout", (req, res) => {

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -38,7 +38,7 @@ module.exports = function (app) {
     const result2 = await db.Mood.findAll();
 
     const result3 = await db.Activity.findAll();
-    
+
     const result4 = await db.Theme.findAll();
 
 

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -39,15 +39,12 @@ module.exports = function (app) {
 
     const result3 = await db.Activity.findAll();
 
-    const result4 = await db.Theme.findAll();
-
 
     res.render("dashboard", {
       style: "dashboard.css",
       entries: result1,
       moods: result2,
-      activities: result3,
-      themes: result4
+      activities: result3
     });
   });
 

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -23,14 +23,16 @@
   <div class="input-field theme col s12">
     <h5>Change Your Theme</h5>
     {{!-- Color Dropdown Trigger --}}
-    <a class="dropdown-trigger btn-large theme-switch" href="#" data-target="dropdown1">Theme<i
+    <a class='dropdown-trigger btn-large theme-switch' href='#' data-target="dropdown1">Theme<i
         class="large material-icons theme-switch">
         arrow_drop_down</i></a>
     {{!-- Color Dropdown Structure --}}
-    <ul id="dropdown1" class="dropdown-content">
-      {{#each themes}}
-      <li><a href="#!" data-id="{{dataValues.id}}">{{dataValues.name}}</a></li>
-      {{/each}}
+    <ul id='dropdown1' class='dropdown-content'>
+      <li><a href="#!" data-id="1" class="lightTheme">Grey</a></li>
+      <li><a href="#!" data-id="2" class="darkTheme">Black</a></li>
+      <li><a href="#!" data-id="3" class="redTheme">Red</a></li>
+      <li><a href="#!" data-id="4" class="blueTheme">Blue</a></li>
+      <li><a href="#!" data-id="5" class="greenTheme">Green</a></li>
     </ul>
   </div>
   <li>
@@ -97,7 +99,7 @@
           <div id="mood">
             <p class="fav-icon"><i class="medium material-icons theme-text" id="fav-mood"> </i></p>
             <p class="fav-name" id="my-mood"></p>
-
+            
           </div>
           <div id="activity">
             <p class="fav-icon"><i class="medium material-icons theme-text" id="fav-activity"> </i></p>

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -23,16 +23,14 @@
   <div class="input-field theme col s12">
     <h5>Change Your Theme</h5>
     {{!-- Color Dropdown Trigger --}}
-    <a class='dropdown-trigger btn-large theme-switch' href='#' data-target="dropdown1">Theme<i
+    <a class="dropdown-trigger btn-large theme-switch" href="#" data-target="dropdown1">Theme<i
         class="large material-icons theme-switch">
         arrow_drop_down</i></a>
     {{!-- Color Dropdown Structure --}}
-    <ul id='dropdown1' class='dropdown-content'>
-      <li><a href="#!" data-id="1" class="lightTheme">Grey</a></li>
-      <li><a href="#!" data-id="2" class="darkTheme">Black</a></li>
-      <li><a href="#!" data-id="3" class="redTheme">Red</a></li>
-      <li><a href="#!" data-id="4" class="blueTheme">Blue</a></li>
-      <li><a href="#!" data-id="5" class="greenTheme">Green</a></li>
+    <ul id="dropdown1" class="dropdown-content">
+      {{#each themes}}
+      <li><a href="#!" data-id="{{dataValues.id}}">{{dataValues.name}}</a></li>
+      {{/each}}
     </ul>
   </div>
   <li>
@@ -99,7 +97,7 @@
           <div id="mood">
             <p class="fav-icon"><i class="medium material-icons theme-text" id="fav-mood"> </i></p>
             <p class="fav-name" id="my-mood"></p>
-            
+
           </div>
           <div id="activity">
             <p class="fav-icon"><i class="medium material-icons theme-text" id="fav-activity"> </i></p>

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -27,12 +27,10 @@
         class="large material-icons theme-switch">
         arrow_drop_down</i></a>
     {{!-- Color Dropdown Structure --}}
-    <ul id='dropdown1' class='dropdown-content'>
-      <li><a href="#!" data-id="1" class="lightTheme">Grey</a></li>
-      <li><a href="#!" data-id="2" class="darkTheme">Black</a></li>
-      <li><a href="#!" data-id="3" class="redTheme">Red</a></li>
-      <li><a href="#!" data-id="4" class="blueTheme">Blue</a></li>
-      <li><a href="#!" data-id="5" class="greenTheme">Green</a></li>
+    <ul id="dropdown1" class="dropdown-content">
+      {{#each themes}}
+      <li><a href="#!" data-id="{{dataValues.id}}">{{dataValues.name}}</a></li>
+      {{/each}}
     </ul>
   </div>
   <li>


### PR DESCRIPTION
I ended up simply adding the default background-color of "transparent" to all of the elements that have the theme-switch class. This prevents the Materialize default colors from appearing on-screen between the removal of the pre-existing color theme class and application of the new one. 

This PR also includes Delphine's new code for creating new color themes dynamically, and my quick fix of changing all instances of "gray" to "grey" in the repo. Don't forget to rebuild the DB after applying this PR (locally and in Heroku). 